### PR TITLE
Add Communica-inspired AngularJS front end

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BasaGas
 
-This project contains a minimal implementation of the BasaGas LPG ordering platform using the MEAN stack. A Node.js/Express backend serves static AngularJS-powered HTML pages so the app can run fully offline once dependencies are installed.
+This project contains a minimal implementation of the BasaGas LPG ordering platform using the MEAN stack. A Node.js/Express backend serves static AngularJS-powered HTML pages styled with a blue and orange theme inspired by [Communica](https://www.communica.co.za/). All client-side dependencies (AngularJS and styles) are included in the repo so the app can run fully offline once Node and MongoDB are installed.
 
 
 ## Prerequisites
@@ -20,6 +20,11 @@ The server listens on `http://localhost:5000` and serves:
 - `/` – Home page
 - `/order.html` – Order form that posts to `POST /api/orders`
 - `/pricing.html` – Pricing table
+ 
+### Required packages
+- **Node.js 18+** and **npm** – runtime and package manager for the server.
+- **MongoDB** – running locally on `mongodb://localhost:27017/basagas`.
+No additional packages are required for the front-end because AngularJS (v1.8.3) is bundled under `backend/public/libs`.
 
 ## Testing
 The backend currently includes placeholder tests:

--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -4,12 +4,28 @@
   <meta charset="UTF-8" />
   <title>BasaGas Home</title>
   <link rel="stylesheet" href="styles.css" />
+  <script src="libs/angular.min.js"></script>
 </head>
 <body>
-  <h1>Welcome to BasaGas</h1>
-  <nav>
-    <a href="/order.html">Order Form</a> |
-    <a href="/pricing.html">Pricing</a>
-  </nav>
+  <header>
+    <div class="container">
+      <h1>BasaGas</h1>
+      <nav>
+        <a href="/">Home</a>
+        <a href="/order.html">Order</a>
+        <a href="/pricing.html">Pricing</a>
+      </nav>
+    </div>
+  </header>
+
+  <section class="hero container">
+    <h2>Gas pick-up, refill & delivery made easy</h2>
+    <p>Convenient door-to-door LPG service for your home or business.</p>
+    <a class="btn" href="/order.html">Place an Order</a>
+  </section>
+
+  <footer class="container">
+    <p>&copy; 2025 BasaGas. All rights reserved.</p>
+  </footer>
 </body>
 </html>

--- a/backend/public/order.html
+++ b/backend/public/order.html
@@ -8,41 +8,54 @@
   <script src="scripts/app.js"></script>
 </head>
 <body ng-controller="OrderController as ctrl">
-  <h1>Order Refill</h1>
-  <form ng-submit="ctrl.submit()">
-    <label>Pickup Address
-      <input type="text" ng-model="ctrl.order.pickupAddress" required />
-    </label>
-    <label>Drop-off Address
-      <input type="text" ng-model="ctrl.order.dropoffAddress" required />
-    </label>
-    <label>Cylinder Size
-      <select ng-model="ctrl.order.cylinderSize" ng-init="ctrl.order.cylinderSize=2" required>
-        <option value="2">2kg</option>
-        <option value="3">3kg</option>
-        <option value="5">5kg</option>
-        <option value="7">7kg</option>
-      </select>
-    </label>
-    <label>Quantity
-      <input type="number" min="1" ng-model="ctrl.order.quantity" ng-init="ctrl.order.quantity=1" required />
-    </label>
-    <label>Return Time
-      <input type="datetime-local" ng-model="ctrl.order.returnTime" required />
-    </label>
-    <fieldset>
-      <legend>Payment Type</legend>
-      <label>
-        <input type="radio" ng-model="ctrl.order.paymentType" value="subscription" /> Subscription
+  <header>
+    <div class="container">
+      <h1>BasaGas</h1>
+      <nav>
+        <a href="/">Home</a>
+        <a href="/order.html">Order</a>
+        <a href="/pricing.html">Pricing</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <h2>Order Refill</h2>
+    <form ng-submit="ctrl.submit()" class="form">
+      <label>Pickup Address
+        <input type="text" ng-model="ctrl.order.pickupAddress" required />
       </label>
-      <label>
-        <input type="radio" ng-model="ctrl.order.paymentType" value="pay-per-refill" ng-checked="true" /> Pay-per-refill
+      <label>Drop-off Address
+        <input type="text" ng-model="ctrl.order.dropoffAddress" required />
       </label>
-    </fieldset>
-    <p>Total Price: {{ ctrl.total() | currency:'R' }}</p>
-    <button type="submit">Submit Order</button>
-  </form>
-  <p ng-if="ctrl.confirmation">Order ID: {{ctrl.confirmation.id}} - Price: {{ctrl.confirmation.price | currency:'R'}}
-  </p>
+      <label>Cylinder Size
+        <select ng-model="ctrl.order.cylinderSize" ng-init="ctrl.order.cylinderSize=2" required>
+          <option value="2">2kg</option>
+          <option value="3">3kg</option>
+          <option value="5">5kg</option>
+          <option value="7">7kg</option>
+        </select>
+      </label>
+      <label>Quantity
+        <input type="number" min="1" ng-model="ctrl.order.quantity" ng-init="ctrl.order.quantity=1" required />
+      </label>
+      <label>Return Time
+        <input type="datetime-local" ng-model="ctrl.order.returnTime" required />
+      </label>
+      <fieldset>
+        <legend>Payment Type</legend>
+        <label>
+          <input type="radio" ng-model="ctrl.order.paymentType" value="subscription" /> Subscription
+        </label>
+        <label>
+          <input type="radio" ng-model="ctrl.order.paymentType" value="pay-per-refill" ng-checked="true" /> Pay-per-refill
+        </label>
+      </fieldset>
+      <p class="total">Total Price: {{ ctrl.total() | currency:'R' }}</p>
+      <button type="submit" class="btn">Submit Order</button>
+    </form>
+    <p ng-if="ctrl.confirmation">Order ID: {{ctrl.confirmation.id}} - Price: {{ctrl.confirmation.price | currency:'R'}}
+    </p>
+  </main>
 </body>
 </html>

--- a/backend/public/pricing.html
+++ b/backend/public/pricing.html
@@ -6,14 +6,27 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <h1>Pricing</h1>
-  <table>
-    <tr><th>Cylinder Size</th><th>Refill Price</th></tr>
-    <tr><td>2kg</td><td>R70</td></tr>
-    <tr><td>3kg</td><td>R104</td></tr>
-    <tr><td>5kg</td><td>R184</td></tr>
-    <tr><td>7kg</td><td>R250</td></tr>
-  </table>
-  <p>Delivery fee: R45 per order. Subscription orders receive a 10% discount.</p>
+  <header>
+    <div class="container">
+      <h1>BasaGas</h1>
+      <nav>
+        <a href="/">Home</a>
+        <a href="/order.html">Order</a>
+        <a href="/pricing.html">Pricing</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <h2>Pricing</h2>
+    <table class="pricing-table">
+      <tr><th>Cylinder Size</th><th>Refill Price</th></tr>
+      <tr><td>2kg</td><td>R70</td></tr>
+      <tr><td>3kg</td><td>R104</td></tr>
+      <tr><td>5kg</td><td>R184</td></tr>
+      <tr><td>7kg</td><td>R250</td></tr>
+    </table>
+    <p>Delivery fee: R45 per order. Subscription orders receive a 10% discount.</p>
+  </main>
 </body>
 </html>

--- a/backend/public/styles.css
+++ b/backend/public/styles.css
@@ -1,3 +1,91 @@
-body { font-family: sans-serif; margin: 2rem; }
-label, fieldset { display: block; margin-bottom: 1rem; }
-nav a { margin-right: 1rem; }
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  background: #f5f5f5;
+  color: #333;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+header {
+  background: #003a70;
+  color: #fff;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+nav {
+  margin-top: 0.5rem;
+}
+
+nav a {
+  color: #fff;
+  margin-right: 1rem;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+nav a:hover {
+  color: #f47b20;
+}
+
+.hero {
+  text-align: center;
+  padding: 4rem 0;
+}
+
+.btn {
+  display: inline-block;
+  background: #f47b20;
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+.form label {
+  display: block;
+  margin-bottom: 1rem;
+}
+
+.form input,
+.form select {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.form fieldset {
+  margin-bottom: 1rem;
+}
+
+.total {
+  font-weight: bold;
+  margin-top: 1rem;
+}
+
+.pricing-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+
+.pricing-table th,
+.pricing-table td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+footer {
+  text-align: center;
+  padding: 2rem 0;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- Style public pages with Communica-inspired blue/orange theme and shared navigation
- Expand order and pricing pages to use new layout and button styles
- Document required packages and offline front-end dependencies

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a657ba6c58832eb6c7afbec0259893